### PR TITLE
Fix ArrayObject extraction on PHP 7.4+

### DIFF
--- a/src/Extractor/EntityExtractorHydratorV2.php
+++ b/src/Extractor/EntityExtractorHydratorV2.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\ApiTools\Hal\Extractor;
 
+use ArrayObject;
 use JsonSerializable;
 use Laminas\ApiTools\Hal\EntityHydratorManager;
 use Laminas\Hydrator\ExtractionInterface;
@@ -66,6 +67,10 @@ class EntityExtractorHydratorV2 implements ExtractionInterface
 
         if ($entity instanceof JsonSerializable) {
             return $entity->jsonSerialize();
+        }
+
+        if ($entity instanceof ArrayObject) {
+            return $entity->getArrayCopy();
         }
 
         return get_object_vars($entity);

--- a/src/Extractor/EntityExtractorHydratorV3.php
+++ b/src/Extractor/EntityExtractorHydratorV3.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\ApiTools\Hal\Extractor;
 
+use ArrayObject;
 use JsonSerializable;
 use Laminas\ApiTools\Hal\EntityHydratorManager;
 use Laminas\Hydrator\ExtractionInterface;
@@ -66,6 +67,10 @@ class EntityExtractorHydratorV3 implements ExtractionInterface
 
         if ($entity instanceof JsonSerializable) {
             return $entity->jsonSerialize();
+        }
+
+        if ($entity instanceof ArrayObject) {
+            return $entity->getArrayCopy();
         }
 
         return get_object_vars($entity);

--- a/test/Extractor/EntityExtractorTest.php
+++ b/test/Extractor/EntityExtractorTest.php
@@ -8,6 +8,7 @@
 
 namespace LaminasTest\ApiTools\Hal\Extractor;
 
+use ArrayObject;
 use Laminas\ApiTools\Hal\EntityHydratorManager;
 use Laminas\ApiTools\Hal\Extractor\EntityExtractor;
 use Laminas\Hydrator\ObjectProperty;
@@ -69,5 +70,17 @@ class EntityExtractorTest extends TestCase
         $data2 = $extractor->extract($entity);
 
         $this->assertSame($data1, $data2);
+    }
+
+    public function testExtractOfArrayObjectEntityWillExtractCorrectly()
+    {
+        $data   = ['id' => 'foo', 'message' => 'FOO'];
+        $entity = new ArrayObject($data);
+        $entityHydratorManager = $this->prophesize(EntityHydratorManager::class);
+        $entityHydratorManager->getHydratorForEntity($entity)->willReturn(null)->shouldBeCalledTimes(1);
+
+        $extractor = new EntityExtractor($entityHydratorManager->reveal());
+
+        $this->assertSame($data, $extractor->extract($entity));
     }
 }


### PR DESCRIPTION
This patch addresses an issue whereby entities created from `ArrayObject` instances or extensions were not being extracted correctly under PHP 7.4+ when no extractor was explicitly mapped.

Fixes #24
